### PR TITLE
Change applying events from implicit to explicit

### DIFF
--- a/Sample.Domain/Aggregates/AccountAggregate.cs
+++ b/Sample.Domain/Aggregates/AccountAggregate.cs
@@ -4,32 +4,35 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class AccountAggregate : AggregateRoot
+    public class AccountAggregate : AggregateRoot<Account>
     {
-        public override AggregateState CreateState() => new Account();
+        public AccountAggregate()
+        {
+            State = new Account();
+        }
 
         public void OpenAccount(Guid owner, string code)
         {
             var e = new AccountOpened(owner, code);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void DepositMoney(decimal amount, Guid transaction)
         {
             var e = new MoneyDeposited(amount, transaction);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void WithdrawMoney(decimal amount, Guid transaction)
         {
             var e = new MoneyWithdrawn(amount, transaction);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CloseAccount(string reason)
         {
             var e = new AccountClosed(reason);
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/PersonAggregate.cs
+++ b/Sample.Domain/Aggregates/PersonAggregate.cs
@@ -4,32 +4,35 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class PersonAggregate : AggregateRoot
+    public class PersonAggregate : AggregateRoot<Person>
     {
-        public override AggregateState CreateState() => new Person();
+        public PersonAggregate()
+        {
+            State = new Person();
+        }
 
         public void BoxPerson()
         {
             var e = new PersonBoxed();
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void UnboxPerson(Person person)
         {
             var e = new PersonUnboxed(person);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void RegisterPerson(string firstName, string lastName, DateTimeOffset registered)
         {
             var e = new PersonRegistered(firstName, lastName, registered);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void RenamePerson(string firstName, string lastName)
         {
             var e = new PersonRenamed(firstName, lastName);
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/TransferAggregate.cs
+++ b/Sample.Domain/Aggregates/TransferAggregate.cs
@@ -4,26 +4,31 @@ using Timeline.Events;
 
 namespace Sample.Domain
 {
-    public class TransferAggregate : AggregateRoot
+    public class TransferAggregate : AggregateRoot<Transfer>
     {
-        public override AggregateState CreateState() => new Transfer();
+        public TransferAggregate()
+        {
+            State = new Transfer();
+        }
+        
+        //public override AggregateState CreateState() => _state;
 
         public void StartTransfer(Guid fromAccount, Guid toAccount, decimal amount)
         {
-            var e = new TransferStarted(fromAccount, toAccount, amount);
-            Apply(e);
+            var transferStartedEvent = new TransferStarted(fromAccount, toAccount, amount);
+            Apply(transferStartedEvent, State.When);
         }
 
         public void UpdateTransfer(string activity)
         {
             var e = new TransferUpdated(activity);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CompleteTransfer()
         {
             var e = new TransferCompleted();
-            Apply(e);
+            Apply(e, State.When);
         }
     }
 }

--- a/Sample.Domain/Aggregates/UserAggregate.cs
+++ b/Sample.Domain/Aggregates/UserAggregate.cs
@@ -2,23 +2,26 @@
 
 namespace Sample.Domain
 {
-    public class UserAggregate : AggregateRoot
+    public class UserAggregate : AggregateRoot<User>
     {
-        public override AggregateState CreateState() => new User();
+        public UserAggregate()
+        {
+            State = new User();
+        }
 
         public void StartRegistration(string name, string password)
         {
             var e = new UserRegistrationStarted(name, password);
-            Apply(e);
+            Apply(e, State.When);
         }
 
         public void CompleteRegistration(string status)
         {
             if (status == "Succeeded")
-                Apply(new UserRegistrationSucceeded());
-            
+                Apply(new UserRegistrationSucceeded(), State.When);
+
             else if (status == "Failed")
-                Apply(new UserRegistrationFailed());
+                Apply(new UserRegistrationFailed(), State.When);
         }
     }
 }

--- a/Sample.Domain/Sample.Domain.csproj
+++ b/Sample.Domain/Sample.Domain.csproj
@@ -3,9 +3,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Timeline\Timeline.csproj" />
   </ItemGroup>
 </Project>

--- a/Sample.Persistence/Logs/Stores/EventStore.cs
+++ b/Sample.Persistence/Logs/Stores/EventStore.cs
@@ -6,7 +6,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text;
-
+using Timeline;
 using Timeline.Events;
 using Timeline.Identities;
 using Timeline.Utilities;
@@ -181,7 +181,7 @@ ORDER BY
                 .Deserialize(Serializer);
         }
 
-        public void Save(AggregateRoot aggregate, IEnumerable<IEvent> events)
+        public void Save(IAggregateRoot aggregate, IEnumerable<IEvent> events)
         {
             var current = _identityService.GetCurrent();
             var tenant = current.Tenant.Identifier;

--- a/Timeline/Events/EventRepository.cs
+++ b/Timeline/Events/EventRepository.cs
@@ -20,7 +20,7 @@ namespace Timeline.Events
         /// <summary>
         /// Gets an aggregate from the event store.
         /// </summary>
-        public T Get<T>(Guid aggregate) where T : AggregateRoot
+        public T Get<T>(Guid aggregate) where T : IAggregateRoot
         {
             return Rehydrate<T>(aggregate);
         }
@@ -28,7 +28,7 @@ namespace Timeline.Events
         /// <summary>
         /// Saves all uncommitted changes to the event store.
         /// </summary>
-        public IEvent[] Save<T>(T aggregate, int? version) where T : AggregateRoot
+        public IEvent[] Save<T>(T aggregate, int? version) where T : IAggregateRoot
         {
             if (version != null && (_store.Exists(aggregate.AggregateIdentifier, version.Value)))
                 throw new ConcurrencyException(aggregate.AggregateIdentifier);
@@ -47,7 +47,7 @@ namespace Timeline.Events
         /// <summary>
         /// Loads an aggregate instance from the full history of events for that aggreate.
         /// </summary>
-        private T Rehydrate<T>(Guid id) where T : AggregateRoot
+        private T Rehydrate<T>(Guid id) where T : IAggregateRoot
         {
             // Get all the events for the aggregate.
             var events = _store.Get(id, -1);
@@ -73,7 +73,7 @@ namespace Timeline.Events
         /// Therefore this function in this class throws a NotImplementedException; refer to SnapshotRepository for the
         /// implementation.
         /// </remarks>
-        public void Box<T>(T aggregate) where T : AggregateRoot
+        public void Box<T>(T aggregate) where T : IAggregateRoot
         {
             throw new NotImplementedException();
         }
@@ -87,7 +87,7 @@ namespace Timeline.Events
         /// Therefore this function in this class throws a NotImplementedException; refer to SnapshotRepository for the
         /// implementation.
         /// </remarks>
-        public T Unbox<T>(Guid aggregateId) where T : AggregateRoot
+        public T Unbox<T>(Guid aggregateId) where T : IAggregateRoot
         {
             throw new NotImplementedException();
         }

--- a/Timeline/Events/IAggregateRoot.cs
+++ b/Timeline/Events/IAggregateRoot.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Timeline.Events
+{
+    public interface IAggregateRoot
+    {
+        public Guid AggregateIdentifier { get; set; }
+
+        public int AggregateVersion { get; set; }
+
+        public AggregateState State { get; set; }
+
+        public IEvent[] FlushUncommittedChanges();
+
+        public IEvent[] GetUncommittedChanges();
+
+        public void Rehydrate(IEnumerable<IEvent> history);
+    }
+}

--- a/Timeline/Events/IEventRepository.cs
+++ b/Timeline/Events/IEventRepository.cs
@@ -10,7 +10,7 @@ namespace Timeline.Events
         /// <summary>
         /// Returns the aggregate identified by the specified id.
         /// </summary>
-        T Get<T>(Guid id) where T : AggregateRoot;
+        T Get<T>(Guid id) where T : IAggregateRoot;
 
         /// <summary>
         /// Saves an aggregate.
@@ -18,16 +18,16 @@ namespace Timeline.Events
         /// <returns>
         /// Returns the events that are now saved (and ready to be published).
         /// </returns>
-        IEvent[] Save<T>(T aggregate, int? version = null) where T : AggregateRoot;
+        IEvent[] Save<T>(T aggregate, int? version = null) where T : IAggregateRoot;
 
         /// <summary>
         /// Copies an aggregate to offline storage and removes it from online logs.
         /// </summary>
-        void Box<T>(T aggregate) where T : AggregateRoot;
+        void Box<T>(T aggregate) where T : IAggregateRoot;
 
         /// <summary>
         /// Retrieves an aggregate from offline storage and returns only its most recent state.
         /// </summary>
-        T Unbox<T>(Guid aggregate) where T : AggregateRoot;
+        T Unbox<T>(Guid aggregate) where T : IAggregateRoot;
     }
 }

--- a/Timeline/Events/IEventStore.cs
+++ b/Timeline/Events/IEventStore.cs
@@ -38,7 +38,7 @@ namespace Timeline.Events
         /// <summary>
         /// Save events.
         /// </summary>
-        void Save(AggregateRoot aggregate, IEnumerable<IEvent> events);
+        void Save(IAggregateRoot aggregate, IEnumerable<IEvent> events);
 
         /// <summary>
         /// Copies an aggregate to offline storage and removes it from online logs.

--- a/Timeline/IAggregateRoot.cs
+++ b/Timeline/IAggregateRoot.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Timeline.Events;
+
+namespace Timeline
+{
+    public interface IAggregateRoot
+    {
+        public Guid AggregateIdentifier { get; set; }
+
+        public int AggregateVersion { get; set; }
+
+        public AggregateState State { get; set;  }
+
+        public IEvent[] FlushUncommittedChanges();
+
+        public IEvent[] GetUncommittedChanges();
+
+        public void Rehydrate(IEnumerable<IEvent> history);
+    }
+}

--- a/Timeline/Snapshots/ISnapshotStrategy.cs
+++ b/Timeline/Snapshots/ISnapshotStrategy.cs
@@ -10,6 +10,6 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Returns true if a snapshot should be taken for the aggregate.
         /// </summary>
-        bool ShouldTakeSnapShot(AggregateRoot aggregate);
+        bool ShouldTakeSnapShot(IAggregateRoot aggregate);
     }
 }

--- a/Timeline/Snapshots/SnapshotRepository.cs
+++ b/Timeline/Snapshots/SnapshotRepository.cs
@@ -11,7 +11,7 @@ namespace Timeline.Snapshots
     /// </summary>
     public class SnapshotRepository : IEventRepository
     {
-        private readonly GuidCache<AggregateRoot> _cache = new GuidCache<AggregateRoot>();
+        private readonly GuidCache<IAggregateRoot> _cache = new GuidCache<IAggregateRoot>();
 
         private readonly ISnapshotStore _snapshotStore;
         private readonly ISnapshotStrategy _snapshotStrategy;
@@ -36,7 +36,7 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Saves the aggregate. Takes a snapshot if needed.
         /// </summary>
-        public IEvent[] Save<T>(T aggregate, int? version = null) where T : AggregateRoot
+        public IEvent[] Save<T>(T aggregate, int? version = null) where T : IAggregateRoot
         {
             // Cache the aggregate for 5 minutes.
             _cache.Add(aggregate.AggregateIdentifier, aggregate, 5 * 60, true);
@@ -51,7 +51,7 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Gets the aggregate.
         /// </summary>
-        public T Get<T>(Guid aggregateId) where T : AggregateRoot
+        public T Get<T>(Guid aggregateId) where T : IAggregateRoot
         {
             // Check the cache to see if the aggregate is already in memory.
             var snapshot = _cache.Get(aggregateId);
@@ -81,7 +81,7 @@ namespace Timeline.Snapshots
         /// <returns>
         /// Returns the version number for the aggregate when the snapshot was taken.
         /// </returns>
-        private int RestoreAggregateFromSnapshot<T>(Guid id, T aggregate) where T : AggregateRoot
+        private int RestoreAggregateFromSnapshot<T>(Guid id, T aggregate) where T : IAggregateRoot
         {
             var snapshot = _snapshotStore.Get(id);
 
@@ -90,7 +90,7 @@ namespace Timeline.Snapshots
 
             aggregate.AggregateIdentifier = snapshot.AggregateIdentifier;
             aggregate.AggregateVersion = snapshot.AggregateVersion;
-            aggregate.State = _eventStore.Serializer.Deserialize<AggregateState>(snapshot.AggregateState, aggregate.CreateState().GetType());
+            aggregate.State = _eventStore.Serializer.Deserialize<AggregateState>(snapshot.AggregateState, aggregate.State.GetType());
 
             return snapshot.AggregateVersion;
         }
@@ -98,7 +98,7 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Saves a snapshot of the aggregate if the strategy indicates a snapshot should now be taken.
         /// </summary>
-        private void TakeSnapshot(AggregateRoot aggregate, bool force)
+        private void TakeSnapshot(IAggregateRoot aggregate, bool force)
         {
             if (!force && !_snapshotStrategy.ShouldTakeSnapShot(aggregate))
                 return;
@@ -124,13 +124,13 @@ namespace Timeline.Snapshots
         {
             var aggregates = _eventStore.GetExpired(DateTimeOffset.UtcNow);
             foreach (var aggregate in aggregates)
-                Box(Get<AggregateRoot>(aggregate));
+                Box(Get<IAggregateRoot>(aggregate));
         }
 
         /// <summary>
         /// Copies an aggregate to offline storage and removes it from online logs.
         /// </summary>
-        public void Box<T>(T aggregate) where T : AggregateRoot
+        public void Box<T>(T aggregate) where T : IAggregateRoot
         {
             TakeSnapshot(aggregate, true);
 
@@ -143,13 +143,13 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Retrieves an aggregate from offline storage and returns only its most recent state.
         /// </summary>
-        public T Unbox<T>(Guid aggregateId) where T : AggregateRoot
+        public T Unbox<T>(Guid aggregateId) where T : IAggregateRoot
         {
             var snapshot = _snapshotStore.Unbox(aggregateId);
             var aggregate = AggregateFactory<T>.CreateAggregate();
             aggregate.AggregateIdentifier = aggregateId;
             aggregate.AggregateVersion = 1;
-            aggregate.State = _eventStore.Serializer.Deserialize<AggregateState>(snapshot.AggregateState, aggregate.CreateState().GetType());
+            aggregate.State = _eventStore.Serializer.Deserialize<AggregateState>(snapshot.AggregateState, aggregate.State.GetType());
             return aggregate;
         }
 

--- a/Timeline/Snapshots/SnapshotStrategy.cs
+++ b/Timeline/Snapshots/SnapshotStrategy.cs
@@ -20,7 +20,7 @@ namespace Timeline.Snapshots
         /// <summary>
         /// Returns true if a snapshot should be taken for the aggregate.
         /// </summary>
-        public bool ShouldTakeSnapShot(AggregateRoot aggregate)
+        public bool ShouldTakeSnapShot(IAggregateRoot aggregate)
         {
             var i = aggregate.AggregateVersion;
             for (var j = 0; j < aggregate.GetUncommittedChanges().Length; j++)


### PR DESCRIPTION
Remove the "black magic" in an Aggregate by explicitly stating through generics what the AggregateState is. When calling the Apply on the Aggregate pass in the method that will be called to perform the action. Keep the implicit methods used when the Aggregate is loaded from the event store.